### PR TITLE
Corrected DB_TYPE value for PostgreSQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Gogs (Go Git Service) Docker Image
 
 This image runs Gogs with SSH & web access. You can configure Gogs via the following environment variables:
 
--	`DB_TYPE` - `mysql` or `postgresql`
+-	`DB_TYPE` - `mysql` or `postgres`
 -	`DB_HOST` - the database server to use, e.g. 127.0.0.1:3306
 -	`DB_NAME` - the name of the database to use
 -	`DB_USER` - the user to connect to the specified database as


### PR DESCRIPTION
Using `DB_TYPE=postgresql` results in error

> [install.go:65 GlobalInit()] [E] Fail to initialize ORM engine: connect to database: Unknown database type: postgresql

[`postgres` is used for PostgreSQL databases instead.](http://gogs.io/docs/advanced/configuration_cheat_sheet.html#database)